### PR TITLE
Added binding to callback

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -70,10 +70,10 @@ export default function (sails) {
     sails.log.silly('sails-hook-webpack: ', stats.toString());
     if (process.env.NODE_ENV === 'development') {
       sails.log.info('sails-hook-webpack: Watching for changes...');
-      hook.compiler.watch(config.hook.watchOptions, hook.afterBuild);
+      hook.compiler.watch(config.hook.watchOptions, hook.afterBuild.bind(hook));
     } else {
       sails.log.info('sails-hook-webpack: Running production build...');
-      hook.compiler.run(hook.afterBuild);
+      hook.compiler.run(hook.afterBuild.bind(hook));
     }
   });
 


### PR DESCRIPTION
Scope is undefined when `NODE_ENV === 'production'`. This causes exception and nodejs terminates.

When `NODE_ENV === 'development'` Watching class in webpack/Compiler binds handler to itself and scope becomes Watching. Which works, but only by accident.

`console.log(this)` in afterBuild prints

> sails-hook-webpack: Webpack loaded.
> sails-hook-webpack: Watching for changes...
> Watching {
>   startTime: 1464073202278,
>   invalid: false,
